### PR TITLE
Feature/#45 skip login vc if logined

### DIFF
--- a/Qcli/SceneDelegate.swift
+++ b/Qcli/SceneDelegate.swift
@@ -16,7 +16,19 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        guard let _ = (scene as? UIWindowScene) else { return }
+        
+        if let isLogined = UserDefaults.standard.object(forKey: "isLogined") as? Bool {
+            if isLogined {
+                guard let scene = (scene as? UIWindowScene) else { return }
+                let window = UIWindow(windowScene: scene)
+                self.window = window
+                window.makeKeyAndVisible()
+                let vc = UIStoryboard(name: "Main", bundle: nil)
+                    .instantiateViewController(identifier: ViewControllerIdentifier.feed.rawValue) as! FeedViewController
+                let navigationController = UINavigationController(rootViewController: vc)
+                window.rootViewController = navigationController
+            }
+        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Qcli/SceneDelegate.swift
+++ b/Qcli/SceneDelegate.swift
@@ -17,15 +17,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         
-        if let isLogined = UserDefaults.standard.object(forKey: "isLogined") as? Bool {
-            if isLogined {
-                guard let scene = (scene as? UIWindowScene) else { return }
-                let window = UIWindow(windowScene: scene)
-                self.window = window
-                window.makeKeyAndVisible()
-                let vc = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "TabView")
-                window.rootViewController = vc
-            }
+        if let isLogined = UserDefaults.standard.object(forKey: "isLogined") as? Bool,
+           isLogined {
+            guard let scene = (scene as? UIWindowScene) else { return }
+            let window = UIWindow(windowScene: scene)
+            self.window = window
+            window.makeKeyAndVisible()
+            let vc = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "TabView")
+            window.rootViewController = vc
         }
     }
 

--- a/Qcli/SceneDelegate.swift
+++ b/Qcli/SceneDelegate.swift
@@ -23,10 +23,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 let window = UIWindow(windowScene: scene)
                 self.window = window
                 window.makeKeyAndVisible()
-                let vc = UIStoryboard(name: "Main", bundle: nil)
-                    .instantiateViewController(identifier: ViewControllerIdentifier.feed.rawValue) as! FeedViewController
-                let navigationController = UINavigationController(rootViewController: vc)
-                window.rootViewController = navigationController
+                let vc = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "TabView")
+                window.rootViewController = vc
             }
         }
     }

--- a/Qcli/ViewController/LoginViewController.swift
+++ b/Qcli/ViewController/LoginViewController.swift
@@ -22,13 +22,6 @@ class LoginViewController: UIViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        //2回目のログインだとログインをスキップさせる
-        if let isLogined = UserDefaults.standard.object(forKey: "isLogined") as? Bool {
-            if isLogined {
-                performSegue(withIdentifier: SegueId.fromLoginToTabBarController.rawValue, sender: nil)
-            }
-        }
-        
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {


### PR DESCRIPTION
## issue
#45 

## 実装したこと
SceneDelegate.swiftで
ログイン状態だとrootViewControllerを
UITabBarControllerに設定

## できるようになったこと
ログイン状態だとLoginVCを表示させない

## 動作確認
ログイン状態→初期画面がFeedVC
非ログイン状態→初期画面がLoginVC